### PR TITLE
Updated proxy URL

### DIFF
--- a/packages/snap/src/constants/config.constant.ts
+++ b/packages/snap/src/constants/config.constant.ts
@@ -9,7 +9,7 @@ export enum ENetworkName {
 export const networksConstant ={
   [ENetworkName.MAINNET]: {
     name: ENetworkName.MAINNET,
-    gqlUrl: 'https://proxy.minaexplorer.com/',
+    gqlUrl: 'https://proxy.minaexplorer.com/graphql',
     gqlTxUrl: 'https://graphql.minaexplorer.com/',
     explorerUrl: 'https://minaexplorer.com/',
     token: {


### PR DESCRIPTION
The bare domain no longer works and needs to be /proxy. More information as to why this happened here https://github.com/MinaProtocol/mina/issues/14501#issuecomment-1792772678